### PR TITLE
Merge header branch

### DIFF
--- a/src/common/toTitleCase.ts
+++ b/src/common/toTitleCase.ts
@@ -1,0 +1,10 @@
+/**
+ * Converts a string to titlecase. E.g. 'hello world' -> 'Hello World'.
+ * @param str - Input string to be converted.
+ * @returns - A string in title case format.
+ */
+export function toTitleCase(str: string) {
+    return str.replace(/\w\S*/g, function (txt) {
+        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+    })
+}

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -67,6 +67,7 @@ export const AccordionTrigger: React.FC<AccordionTriggerProps> = React.forwardRe
                         group
                         flex
                         flex-1
+                        select-none
                         items-center
                         justify-between
                         px-3

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,9 +17,10 @@ interface HeaderProps {
     className?: string
     opacity?: number
     colour?: string
+    children?: React.ReactNode
 }
 
-const Header: React.FC<HeaderProps> = ({ className, opacity, colour }) => {
+const Header: React.FC<HeaderProps> = ({ className, opacity, colour, children }) => {
     const { user } = useAuth()
     const navigate = useNavigate()
     const location = useLocation()
@@ -32,11 +33,11 @@ const Header: React.FC<HeaderProps> = ({ className, opacity, colour }) => {
                 gradient={true}
             />
             {/* Header container */}
-            <div className="mx-auto h-[32px] max-w-[1400px]">
+            <div className="mx-auto h-fit max-w-[1400px]">
                 {/* Header content */}
-                <header className="m-4 flex select-none items-center justify-between">
-                    {/* {Router Buttons} */}
-                    <div className="hidden h-full gap-x-2 md:flex">
+                <header className="m-4 flex select-none flex-nowrap items-center justify-between gap-x-2">
+                    {/* {Router buttons} */}
+                    <div className="hidden shrink-0 gap-x-2 md:flex">
                         <Button
                             onClick={() => navigate(-1)}
                             disabled={location.key === 'default'}
@@ -52,8 +53,8 @@ const Header: React.FC<HeaderProps> = ({ className, opacity, colour }) => {
                             <RxCaretRight size={32} />
                         </Button>
                     </div>
-                    {/* {Mobile Buttons} */}
-                    <div className="flex gap-x-4 md:hidden">
+                    {/* {Mobile buttons} */}
+                    <div className="flex shrink-0 gap-x-2 md:hidden">
                         <Button
                             onClick={() => navigate('/')}
                             className="bg-white p-2"
@@ -67,8 +68,17 @@ const Header: React.FC<HeaderProps> = ({ className, opacity, colour }) => {
                             <HiSearch size={20} />
                         </Button>
                     </div>
-                    {/* {Account Buttons} */}
-                    <div className="flex h-full items-center gap-x-2">
+                    {/* Content information */}
+                    <div
+                        className={twMerge(
+                            'pointer-events-none flex w-full items-center gap-x-2 overflow-hidden opacity-0 transition duration-700',
+                            opacity === 1 && 'opacity-1 pointer-events-auto'
+                        )}
+                    >
+                        {children}
+                    </div>
+                    {/* {Account buttons} */}
+                    <div className="flex shrink-0 items-center gap-x-2">
                         {user ? (
                             <>
                                 <Button

--- a/src/components/library/LibraryItem.tsx
+++ b/src/components/library/LibraryItem.tsx
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router-dom'
 import { twMerge } from 'tailwind-merge'
 
+import { toTitleCase } from '../../common/toTitleCase'
+
 interface LibraryItemProps {
     image: string
     title: string
@@ -12,12 +14,6 @@ interface LibraryItemProps {
 
 const LibraryItem: React.FC<LibraryItemProps> = ({ image, title, type, author, active, href }) => {
     const navigate = useNavigate()
-
-    function toTitleCase(str: string) {
-        return str.replace(/\w\S*/g, function (txt) {
-            return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
-        })
-    }
 
     return (
         <div

--- a/src/components/library/LikedSongs.tsx
+++ b/src/components/library/LikedSongs.tsx
@@ -19,6 +19,7 @@ const LikedSongs: React.FC<LikedSongsProps> = ({ active, href }) => {
                 flex
                 w-full
                 flex-1
+                select-none
                 items-center
                 justify-between
                 px-3

--- a/src/components/wrappers/AlbumWrapper.tsx
+++ b/src/components/wrappers/AlbumWrapper.tsx
@@ -6,9 +6,11 @@ import { Album } from '../../types/Album'
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
 import { convertAlbumDuration } from '../../common/convertAlbumDuration'
+import { toTitleCase } from '../../common/toTitleCase'
 
 import Header from '../Header'
-import ContentWrapper from './ContentScrollWrapper'
+import PlayButton from '../PlayButton'
+import ScrollWrapper from './ScrollWrapper'
 import HeaderSpacer from '../HeaderSpacer'
 import BackgroundGradient from '../BackgroundGradient'
 
@@ -26,13 +28,22 @@ const AlbumWrapper: React.FC<AlbumWrapperProps> = ({ album, colour, children }) 
         album.tracks.items.reduce((n, { duration_ms }) => n + duration_ms, 0).toString()
     )
 
+    console.log(album)
+
     return (
         <>
             <Header
                 opacity={opacity}
                 colour={colour}
-            />
-            <ContentWrapper contentRef={contentRef}>
+            >
+                <PlayButton
+                    contentId={album.id}
+                    size={24}
+                    className="absolute"
+                />
+                <span className="truncate pl-14 text-2xl font-bold">{album.name}</span>
+            </Header>
+            <ScrollWrapper contentRef={contentRef}>
                 {/* Heading container */}
                 <div
                     className="h-fit w-[full] pb-4 md:h-[280px]"
@@ -49,6 +60,7 @@ const AlbumWrapper: React.FC<AlbumWrapperProps> = ({ album, colour, children }) 
                             flex
                             h-full
                             max-w-[1400px]
+                            select-none
                             flex-col
                             px-4
                             md:flex-row
@@ -96,7 +108,7 @@ const AlbumWrapper: React.FC<AlbumWrapperProps> = ({ album, colour, children }) 
                             "
                         >
                             {/* Details */}
-                            <p className="hidden md:block">Album</p>
+                            <p className="hidden md:block">{toTitleCase(album.album_type)}</p>
                             <p
                                 className="
                                     text-3xl
@@ -169,7 +181,7 @@ const AlbumWrapper: React.FC<AlbumWrapperProps> = ({ album, colour, children }) 
                         {children}
                     </section>
                 </div>
-            </ContentWrapper>
+            </ScrollWrapper>
         </>
     )
 }

--- a/src/components/wrappers/ArtistWrapper.tsx
+++ b/src/components/wrappers/ArtistWrapper.tsx
@@ -4,8 +4,11 @@ import { Artist } from '../../types/Artist'
 
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
+import { toTitleCase } from '../../common/toTitleCase'
+
 import Header from '../Header'
-import ContentWrapper from './ContentScrollWrapper'
+import PlayButton from '../PlayButton'
+import ScrollWrapper from './ScrollWrapper'
 import HeaderSpacer from '../HeaderSpacer'
 import BackgroundGradient from '../BackgroundGradient'
 
@@ -25,8 +28,15 @@ const ArtistWrapper: React.FC<ArtistWrapperProps> = ({ artist, colour, children 
             <Header
                 opacity={opacity}
                 colour={colour}
-            />
-            <ContentWrapper contentRef={contentRef}>
+            >
+                <PlayButton
+                    contentId={artist.id}
+                    size={24}
+                    className="absolute"
+                />
+                <span className="truncate pl-14 text-2xl font-bold">{artist.name}</span>
+            </Header>
+            <ScrollWrapper contentRef={contentRef}>
                 {/* Heading container */}
                 <div
                     className="h-fit w-[full] pb-4 md:h-[280px]"
@@ -43,6 +53,7 @@ const ArtistWrapper: React.FC<ArtistWrapperProps> = ({ artist, colour, children 
                             flex
                             h-full
                             max-w-[1400px]
+                            select-none
                             flex-col
                             px-4
                             md:flex-row
@@ -90,7 +101,7 @@ const ArtistWrapper: React.FC<ArtistWrapperProps> = ({ artist, colour, children 
                             "
                         >
                             {/* Details */}
-                            <p className="hidden md:block">Artist</p>
+                            <p className="hidden md:block">{toTitleCase(artist.type)}</p>
                             <p
                                 className="
                                     text-3xl
@@ -120,7 +131,7 @@ const ArtistWrapper: React.FC<ArtistWrapperProps> = ({ artist, colour, children 
                         {children}
                     </section>
                 </div>
-            </ContentWrapper>
+            </ScrollWrapper>
         </>
     )
 }

--- a/src/components/wrappers/HomeWrapper.tsx
+++ b/src/components/wrappers/HomeWrapper.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../../hooks/useAuth'
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
 import Header from '../Header'
-import ContentWrapper from './ContentScrollWrapper'
+import ScrollWrapper from './ScrollWrapper'
 import HeaderSpacer from '../HeaderSpacer'
 import BackgroundGradient from '../BackgroundGradient'
 // import BackgroundColour from '../BackgroundColour'
@@ -25,7 +25,7 @@ const HomeWrapper: React.FC<HomeWrapperProps> = ({ colour, children }) => {
                 opacity={opacity}
                 colour={colour}
             />
-            <ContentWrapper contentRef={contentRef}>
+            <ScrollWrapper contentRef={contentRef}>
                 {user ? (
                     <>
                         {/* Background gradient */}
@@ -66,7 +66,7 @@ const HomeWrapper: React.FC<HomeWrapperProps> = ({ colour, children }) => {
                         </div>
                     </>
                 )}
-            </ContentWrapper>
+            </ScrollWrapper>
         </>
     )
 }

--- a/src/components/wrappers/PlaylistWrapper.tsx
+++ b/src/components/wrappers/PlaylistWrapper.tsx
@@ -6,9 +6,11 @@ import { Track } from '../../types/Track'
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
 import { convertAlbumDuration } from '../../common/convertAlbumDuration'
+import { toTitleCase } from '../../common/toTitleCase'
 
 import Header from '../Header'
-import ContentWrapper from './ContentScrollWrapper'
+import PlayButton from '../PlayButton'
+import ScrollWrapper from './ScrollWrapper'
 import HeaderSpacer from '../HeaderSpacer'
 import BackgroundGradient from '../BackgroundGradient'
 
@@ -35,8 +37,15 @@ const PlaylistWrapper: React.FC<PlaylistWrapperProps> = ({ playlist, tracks, col
             <Header
                 opacity={opacity}
                 colour={colour}
-            />
-            <ContentWrapper contentRef={contentRef}>
+            >
+                <PlayButton
+                    contentId={playlist.id}
+                    size={24}
+                    className="absolute"
+                />
+                <span className="truncate pl-14 text-2xl font-bold">{playlist.name}</span>
+            </Header>
+            <ScrollWrapper contentRef={contentRef}>
                 {/* Heading container */}
                 <div
                     className="h-fit w-[full] pb-4 md:h-[280px]"
@@ -53,6 +62,7 @@ const PlaylistWrapper: React.FC<PlaylistWrapperProps> = ({ playlist, tracks, col
                             flex
                             h-full
                             max-w-[1400px]
+                            select-none
                             flex-col
                             px-4
                             md:flex-row
@@ -100,7 +110,7 @@ const PlaylistWrapper: React.FC<PlaylistWrapperProps> = ({ playlist, tracks, col
                             "
                         >
                             {/* Details */}
-                            <p className="hidden md:block">Playlist</p>
+                            <p className="hidden md:block">{toTitleCase(playlist.type)}</p>
                             <p
                                 className="
                                     text-3xl
@@ -142,7 +152,7 @@ const PlaylistWrapper: React.FC<PlaylistWrapperProps> = ({ playlist, tracks, col
                                     </a>
                                 </span>
                                 <span className="mx-1 hidden md:block">&bull;</span>
-                                <span>{followers} Followers</span>
+                                <span>{followers} saves</span>
                                 <span className="mx-1 hidden md:block">&bull;</span>
                                 <span>
                                     {songs} {songs === '1' ? 'song' : 'songs'}, {totalListeningLength}
@@ -166,7 +176,7 @@ const PlaylistWrapper: React.FC<PlaylistWrapperProps> = ({ playlist, tracks, col
                         {children}
                     </section>
                 </div>
-            </ContentWrapper>
+            </ScrollWrapper>
         </>
     )
 }

--- a/src/components/wrappers/ProfileWrapper.tsx
+++ b/src/components/wrappers/ProfileWrapper.tsx
@@ -5,7 +5,7 @@ import { User } from '../../types/User'
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
 import Header from '../Header'
-import ContentWrapper from './ContentScrollWrapper'
+import ScrollWrapper from './ScrollWrapper'
 import HeaderSpacer from '../HeaderSpacer'
 import BackgroundGradient from '../BackgroundGradient'
 
@@ -24,8 +24,10 @@ const ProfileWrapper: React.FC<ProfileWrapperProps> = ({ user, colour, children 
             <Header
                 opacity={opacity}
                 colour={colour}
-            />
-            <ContentWrapper contentRef={contentRef}>
+            >
+                <span className="truncate text-2xl font-bold">{user.display_name}</span>
+            </Header>
+            <ScrollWrapper contentRef={contentRef}>
                 {/* Heading container */}
                 <div
                     className="h-fit w-[full] pb-4 md:h-[280px]"
@@ -42,6 +44,7 @@ const ProfileWrapper: React.FC<ProfileWrapperProps> = ({ user, colour, children 
                             flex
                             h-full
                             max-w-[1400px]
+                            select-none
                             flex-col
                             px-4
                             md:flex-row
@@ -119,7 +122,7 @@ const ProfileWrapper: React.FC<ProfileWrapperProps> = ({ user, colour, children 
                         {children}
                     </section>
                 </div>
-            </ContentWrapper>
+            </ScrollWrapper>
         </>
     )
 }

--- a/src/components/wrappers/ScrollWrapper.tsx
+++ b/src/components/wrappers/ScrollWrapper.tsx
@@ -4,12 +4,12 @@ import { useScroll } from 'framer-motion'
 import ScrollArea from '../ScrollArea'
 import useScrollOpacity from '../../hooks/useScrollOpacity'
 
-interface ContentWrapperProps {
+interface ScrollWrapperProps {
     children: React.ReactNode
     contentRef?: React.RefObject<HTMLElement>
 }
 
-const ContentWrapper: React.FC<ContentWrapperProps> = ({ contentRef, children }) => {
+const ScrollWrapper: React.FC<ScrollWrapperProps> = ({ contentRef, children }) => {
     const { setOpacity } = useScrollOpacity()
     const scrollAreaRef = useRef(null)
 
@@ -22,9 +22,15 @@ const ContentWrapper: React.FC<ContentWrapperProps> = ({ contentRef, children })
     })
 
     useEffect(() => {
+        // Set opacity to initial scrollYProgress on mount
+        setOpacity(scrollYProgress.get())
+
+        // Subscribe to scrollYProgress changes
         const unsubscribe = scrollYProgress.on('change', (value) => setOpacity(value))
+
+        // Cleanup on unmount
         return () => unsubscribe()
-    })
+    }, [scrollYProgress, setOpacity])
 
     return (
         <>
@@ -38,4 +44,4 @@ const ContentWrapper: React.FC<ContentWrapperProps> = ({ contentRef, children })
     )
 }
 
-export default ContentWrapper
+export default ScrollWrapper


### PR DESCRIPTION
- Added a content information section to the Header component that displays on page scroll using the framer-motion useOpacity hook.
- Fixed a bug with the ScrollWrapper component where the opacity remained at the old value from the previous component on remount. Opacity now sets to new scrollYProgress value on mount.
- Added select-none styling to content wrapper headings and library sections.